### PR TITLE
Add helga-karma plugin to helga.

### DIFF
--- a/helga/settings.py
+++ b/helga/settings.py
@@ -46,6 +46,7 @@ ENABLED_PLUGINS = [
     'reviewboard',
     'stfu',
     'wiki_whois',
+    'karma',
 
     # Sometimes, giphy may give back a gif of questionable content
     # 'giphy',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytz==2013b
 pyOpenSSL==0.13
 requests==1.2.3
 BeautifulSoup==3.2.1
+helga-karma==0.1.3
 
 # Because it handles optional arguments better
 -e git://github.com/shaunduncan/smokesignal.git@e66cf26576#egg=smokesignal


### PR DESCRIPTION
At my former office (and in several PDX-centric IRC channels) we were/are using a similar plugin for PMXBot, and it has proven to be a really great way of making sure everybody feels supported and appreciated by their fellow team members.

(Depending upon how you're managing our helga instance, you may not want to actually accept this PR, but this seemed like a solid way of apprising you of the fact that I wrote [a thing](https://github.com/coddingtonbear/helga-karma).)
