### PR TITLE
added single/global replacement and case insensitivity

### DIFF
--- a/helga/plugins/meant_to_say.py
+++ b/helga/plugins/meant_to_say.py
@@ -3,7 +3,7 @@ import re
 from helga.plugins import match
 
 
-@match(r'^s/(.*?)/(.*?)/?$')
+@match(r'^s/(.*?)/(.*?)(/.*?)?$')
 def meant_to_say(client, channel, nick, message, matches):
     """
     A plugin so users can correct what they have said. For example::
@@ -17,8 +17,13 @@ def meant_to_say(client, channel, nick, message, matches):
     except KeyError:
         return None
 
-    old, new = matches[0]
-    modified = re.sub(old, new, last)
+    old, new, reflags = matches[0]
+    count = 1
+    if re.search('g', reflags, re.I):
+        count = 0
+    if re.search('i', reflags, re.I):
+        flags = re.I
+    modified = re.sub(old, new, last, count, flags)
 
     # Don't respond if we don't replace anything ... it's annoying
     if modified != last:


### PR DESCRIPTION
amcm: When I'm looking at the there's all 908 lines in the file, with out any filtering
amcm: s/the/8942/
helga: amcm meant to say: When I'm looking at 8942 8942re's all 908 lines in 8942 file, with out any filtering
