### PR TITLE
remove unavailable image from imgur

### DIFF
--- a/helga/plugins/oneliner.py
+++ b/helga/plugins/oneliner.py
@@ -58,7 +58,6 @@ RESPONSES = {
     r'^nope$': (imgur('iSm1aZu'),   # Arrested development NOPE
                 imgur('2xwe756'),   # Lonley island like a boss NOPE
                 imgur('zCtbl'),     # Tracy Morgan NOPE
-                imgur('ErtgS'),     # Spok NOPE button
                 imgur('foEHo'),     # Spongebob buried in sand
                 imgur('xKYs9'),     # Puppy does not like lime
                 imgur('ST9lw3U'),   # Seinfeld I'm Out


### PR DESCRIPTION
![screen shot 2014-07-01 at 3 42 09 pm](https://cloud.githubusercontent.com/assets/317847/3448323/debf3a16-0157-11e4-8f4c-a20e0781ace9.png)
The linked that was nixed in this PR is no longer available in imgur.com
