### PR TITLE
Add a replace command to the facts plugin

### DIFF
--- a/helga/plugins/facts.py
+++ b/helga/plugins/facts.py
@@ -78,9 +78,24 @@ def forget_fact(term):
     return random.choice(ACKS)
 
 
+def replace_fact(term, fact, author=''):
+    """
+    Replaces an existing fact by removing it, then adding the new definition
+    """
+    forget_fact(term)
+    add_fact(term, fact, author)
+    return random.choice(ACKS)
+
+
 def facts_command(client, channel, nick, message, cmd, args):
     if cmd == 'forget':
         return forget_fact(' '.join(args))
+    if cmd == 'replace':
+        if '<with>' not in args:
+            return 'No definition supplied.'
+        all_args = ' '.join(args)
+        term, fact = all_args.split(' <with> ', 1)
+        return replace_fact(term, fact, author=nick)
 
 
 def facts_match(client, channel, nick, message, found):
@@ -141,6 +156,12 @@ def facts(client, channel, nick, message, *args):
 
         <sduncan> helga forget foo
         <helga> forgotten
+
+    To replace a fact, you must use the ``replace`` command, andprovide the
+    term as well as the new definition, separated by  '<watch>'::
+
+        <sduncan> helga replace foo <with> new def
+        <helga> replaced
     """
     if len(args) == 2:
         return facts_command(client, channel, nick, message, *args)

--- a/helga/tests/plugins/test_facts.py
+++ b/helga/tests/plugins/test_facts.py
@@ -204,6 +204,32 @@ def test_facts_command():
     assert facts.facts_command(None, '#bots', 'me', '!forget foo', 'foobar', args) is None
 
 
+@patch('helga.plugins.facts.forget_fact')
+@patch('helga.plugins.facts.add_fact')
+def test_replace_fact(add, forget):
+    facts.replace_fact('term', 'definition', author='person')
+    forget.assert_called_with('term')
+    add.assert_called_with(
+        'term',
+        'definition',
+        'person',
+    )
+
+
+def test_replace_facts_command():
+    facts.replace_fact = lambda x, y, author: (x, y, author)
+    args = ['term1', 'term2', '<with>', 'def1', 'def2']
+    assert (u'term1 term2', u'def1 def2', u'me') == facts.facts_command(None,
+        '#bots', 'me', '!replace term1 term2 <with> def1 def2', 'replace', args)
+
+
+def test_replace_facts_missing_pipe_command():
+    facts.replace_fact = lambda x, y, author: (x, y, author)
+    args = ['term1', 'term2', 'def1', 'def2']
+    assert (u'No definition supplied.') == facts.facts_command(None,
+        '#bots', 'me', '!replace term1 term2 <with> def1 def2', 'replace', args)
+
+
 @patch('helga.plugins.facts.facts_match')
 @patch('helga.plugins.facts.facts_command')
 def test_facts_plugin(cmd, match):


### PR DESCRIPTION
The replace command is a shortcut for removing an existing fact then
adding a new definition for the same term.
