### PR TITLE
track "/me" IRC actions

### DIFF
--- a/helga/comm/irc.py
+++ b/helga/comm/irc.py
@@ -279,6 +279,11 @@ class Client(irc.IRCClient):
         # Update last message
         self.last_message[channel][user] = message
 
+    """
+    Handle IRC "/me" messages the same as regular IRC messages.
+    """
+    action = privmsg
+
     def alterCollidedNick(self, nickname):
         """
         Called when the both has a nickname collision. This will generate a new nick

--- a/helga/tests/comm/test_irc.py
+++ b/helga/tests/comm/test_irc.py
@@ -138,6 +138,18 @@ class ClientTestCase(TestCase):
 
         assert self.client.msg.call_args[0][0] == 'foo'
 
+    @patch('helga.comm.irc.registry')
+    def test_action(self, registry):
+        self.client.msg = Mock()
+        registry.process.return_value = ['eats the snack']
+
+        self.client.action('foo!~bar@baz', '#bots', 'offers helga a snack')
+
+        args = self.client.msg.call_args[0]
+        assert args[0] == '#bots'
+        assert args[1] == 'eats the snack'
+
+
     @patch('helga.comm.irc.settings')
     @patch('helga.comm.irc.irc.IRCClient')
     def test_connectionMade(self, irc, settings):


### PR DESCRIPTION
Twisted tracks normal IRC messages using the privmsg() method and "/me" IRC messages using the action() method.

This pull request aliases the action method to the privmsg method so that Helga will process both types of messages. This change allows plugins to trigger on content in "/me" IRC messages.