### PR TITLE
fix typo in irc.py comments

### DIFF
--- a/helga/comm/irc.py
+++ b/helga/comm/irc.py
@@ -281,7 +281,7 @@ class Client(irc.IRCClient):
 
     def alterCollidedNick(self, nickname):
         """
-        Called when the both has a nickname collision. This will generate a new nick
+        Called when the bot has a nickname collision. This will generate a new nick
         containing the perferred nick and the current timestamp.
 
         :param nickname: the nickname that was already taken


### PR DESCRIPTION
This pull request fixes a simple typo: "the both" -> "the bot"