### PR TITLE
handle missing !plugins arguments

### DIFF
--- a/helga/plugins/manager.py
+++ b/helga/plugins/manager.py
@@ -81,7 +81,10 @@ def manager(client, channel, nick, message, cmd, args):
     """
     Manages listing plugins, or enabling and disabling them
     """
-    subcmd = args[0]
+    if len(args) < 1:
+        subcmd = 'list'
+    else:
+        subcmd = args[0]
 
     if subcmd == 'list':
         return list_plugins(client, channel)

--- a/helga/tests/plugins/test_manager.py
+++ b/helga/tests/plugins/test_manager.py
@@ -131,6 +131,7 @@ def test_manager_plugin(list, enable, disable):
     enable.return_value = 'enable'
     disable.return_value = 'disable'
 
+    assert 'list' == manager.manager('client', '#bots', 'me', 'message', 'plugins', [])
     assert 'list' == manager.manager('client', '#bots', 'me', 'message', 'plugins', ['list'])
     assert 'enable' == manager.manager('client', '#bots', 'me', 'message', 'plugins', ['enable'])
     assert 'disable' == manager.manager('client', '#bots', 'me', 'message', 'plugins', ['disable'])


### PR DESCRIPTION
Prior to this commit, if a user posted `!plugins` with no other arguments to helga, helga would error with a strack trace. We were referencing the `args` list's first element without verifying that the `args` list has a first element.

Update the `!plugins` command so that it doesn't crash and calls the same code path as `!plugins list` instead. The assumption is that this is generally what the user would want.