### PR TITLE
bump pyOpenSSL req 0.13 to 0.14 to work with modern (~ 1.0.2) openssl versions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,10 +22,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :private_network, ip: "192.168.10.101"
 
   config.vm.provision "shell", inline: <<EOF
-
 # Update and install system dependencies
 apt-get update -qq
 apt-get install -qqy --force-yes \
+  git \
   mongodb \
   ngircd \
   openssl \
@@ -33,7 +33,9 @@ apt-get install -qqy --force-yes \
   python-dev \
   python-pip \
   python-setuptools \
-  python-virtualenv
+  python-virtualenv \
+  libffi6 \
+  libffi-dev
 
 # Allow external mongo connections
 sed -i -s 's/^bind_ip = 127.0.0.1/#bind_ip = 127.0.0.1/' /etc/mongodb.conf
@@ -42,12 +44,15 @@ service mongodb restart
 # Create a virtualenv for helga and install
 sudo -u vagrant virtualenv /home/vagrant/helga_venv
 pushd /vagrant
+# upgrade pip from the archaic 1.1
+sudo -u vagrant /home/vagrant/helga_venv/bin/pip install --upgrade pip
+# install helga
 sudo -u vagrant /home/vagrant/helga_venv/bin/python setup.py develop
 popd
 
 # Make sure the default profile activates the venv
 sudo -u vagrant echo "#!/bin/bash" > /home/vagrant/.profile
-sudo -u vagrant echo "source /home/vagrant/helga_venv/bin/active" >> /home/vagrant/.profile
+sudo -u vagrant echo "source /home/vagrant/helga_venv/bin/activate" >> /home/vagrant/.profile
 sudo -u vagrant echo "cd /vagrant/" >> /home/vagrant/.profile
 
 EOF

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -9,8 +9,10 @@ Getting Started
 Requirements
 ------------
 All python requirements for running helga are listed in ``requirements.txt``. Helga
-supports SSL connections to a chat server (currently IRC, XMPP, and HipChat), and for this reason,
-you will need to install both ``openssl`` and ``libssl-dev`` in order to compile SSL support.
+supports SSL connections to a chat server (currently IRC, XMPP, and HipChat); in order to compile
+SSL support, you will need to install both ``openssl`` and ``libssl-dev`` packages, as well as
+``libffi6`` and ``libffi-dev`` (the latter are required for ``cffi``, needed by ``pyOpenSSL``
+version 0.14 or later).
 
 Optionally, you can have Helga configured to connect to a MongoDB server. Although
 this is not strictly required, many plugins require a connection to operate, so it

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,11 @@
 # openssl
 # libssl-dev
 # mongodb
+#   for cffi==1.1.0, required by pyOpenSSL>=0.14:
+# libffi6
+# libffi-dev
 
+cffi==1.1.0
 decorator==3.4.0
 pymongo==2.5.2
 pyOpenSSL==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 
 decorator==3.4.0
 pymongo==2.5.2
-pyOpenSSL==0.13
+pyOpenSSL==0.14
 pystache==0.5.4
 smokesignal==0.5
 Twisted==13.1.0


### PR DESCRIPTION
Helga won't install anymore on my Arch Linux (rolling release) system, because pyOpenSSL <= 0.13 is incompatible with newer OpenSSL versions (I don't have the exact version that introduced the problem, but I'm running 1.0.2.a-1).

see https://github.com/pyca/pyopenssl/issues/276

FWIW, I couldn't find any documentation for Twisted on exactly what pyOpenSSL version it requires :(