### PR TITLE
requirements.txt: unpin pymongo and ssl dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@
 # libffi6
 # libffi-dev
 
-cffi==1.1.0
+cffi
 decorator==3.4.0
-pymongo==2.5.2
-pyOpenSSL==0.14
+pymongo
+pyOpenSSL
 pystache==0.5.4
 smokesignal==0.5
 Twisted==13.1.0


### PR DESCRIPTION
Newer versions of the cryptography module (I tested v1.3.1, but probably others) have a dependency on cffi >= 1.4.1, so this causes errors when we've pinned to such an old cffi version.

The exact error I was getting during installation:

    error: cffi 1.1.0 is installed but cffi>=1.4.1 is required by set(['cryptography'])

This change fixes the error.