### PR TITLE
requirements.txt: unpin twisted dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pymongo
 pyOpenSSL
 pystache==0.5.4
 smokesignal==0.5
-Twisted==13.1.0
+Twisted


### PR DESCRIPTION
This allows us to use plugins that depend on Twisted's "treq" module, since that module requires newer versions of Twisted.