### PR TITLE
avoid "ur" string prefix

### DIFF
--- a/helga/plugins/__init__.py
+++ b/helga/plugins/__init__.py
@@ -535,7 +535,7 @@ class Command(Plugin):
         prefixes = filter(bool, [nick_prefix, getattr(settings, 'COMMAND_PREFIX_CHAR', '!')])
         prefix = '({0})'.format('|'.join(prefixes))
 
-        pat = ur'^{0}({1})($|\s(.*)$)'.format(prefix, '|'.join(choices))
+        pat = r'^{0}({1})($|\s(.*)$)'.format(prefix, '|'.join(choices))
 
         try:
             _, cmd, _, argstr = re.findall(pat, message, re.IGNORECASE)[0]


### PR DESCRIPTION
Python 3.3 dropped support for `ur` strings in https://bugs.python.org/issue15096 . Switch to `r` to avoid the `SyntaxError` on import.