### PR TITLE
requirements.txt: unpin smokesignal dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ decorator==3.4.0
 pymongo
 pyOpenSSL
 pystache==0.5.4
-smokesignal==0.5
+smokesignal
 Twisted
 requests


### PR DESCRIPTION
This allows us to use plugins that depend on newer versions of smokesignal.