### PR TITLE
fix(dependabot): quote time values as strings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 09:00
+      time: "09:00"
     open-pull-requests-limit: 10
     labels:
       - dependencies
@@ -44,7 +44,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 09:00
+      time: "09:00"
     open-pull-requests-limit: 5
     labels:
       - dependencies
@@ -59,7 +59,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 09:00
+      time: "09:00"
     open-pull-requests-limit: 5
     labels:
       - dependencies


### PR DESCRIPTION
YAML interprets `09:00` as a sexagesimal integer (540), which causes Dependabot to fail validating the config.

```
The property '#/updates/0/schedule/time' of type integer did not match the following type: string
```

Fix by quoting the time values so they're parsed as strings.